### PR TITLE
feat: identify lazy or sync transaction creation [SF-601]

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -5,6 +5,7 @@ type Transaction @entity {
   side: Int!
   orderPrice: BigInt!
   taker: User!
+  executionType: TransactionExecutionType!
 
   forwardValue: BigInt!
   amount: BigInt!
@@ -46,6 +47,11 @@ type LendingMarket @entity {
   protocol: Protocol!
   volume: BigInt!
   dailyVolume: [DailyVolume!]! @derivedFrom(field: "lendingMarket")
+}
+
+enum TransactionExecutionType {
+  Sync
+  Lazy
 }
 
 enum OrderStatus {

--- a/src/lending-market.ts
+++ b/src/lending-market.ts
@@ -63,7 +63,8 @@ export function handleOrdersTaken(event: OrdersTaken): void {
         event.params.filledFutureValue,
         event.block.timestamp,
         event.block.number,
-        event.transaction.hash
+        event.transaction.hash,
+        'Sync'
     );
     addToTransactionVolume(event);
 }
@@ -111,7 +112,8 @@ export function handleOrdersCleaned(event: OrdersCleaned): void {
                 ),
                 event.block.timestamp,
                 event.block.number,
-                event.transaction.hash
+                event.transaction.hash,
+                'Lazy'
             );
             order.filledAmount = order.amount;
             order.status = 'Filled';
@@ -145,7 +147,8 @@ export function handleOrderPartiallyTaken(event: OrderPartiallyTaken): void {
             event.params.filledFutureValue,
             event.block.timestamp,
             event.block.number,
-            event.transaction.hash
+            event.transaction.hash,
+            'Sync'
         );
 
         order.save();
@@ -163,7 +166,8 @@ function createTransaction(
     filledFutureValue: BigInt,
     timestamp: BigInt,
     blockNumber: BigInt,
-    txHash: Bytes
+    txHash: Bytes,
+    executionType: string
 ): void {
     if (filledAmount.isZero()) return;
     const transaction = new Transaction(txId);
@@ -173,6 +177,7 @@ function createTransaction(
     transaction.currency = ccy;
     transaction.maturity = maturity;
     transaction.side = side;
+    transaction.executionType = executionType;
 
     transaction.forwardValue = filledFutureValue;
     transaction.amount = filledAmount;

--- a/test/lending-market.test.ts
+++ b/test/lending-market.test.ts
@@ -255,67 +255,36 @@ test('Should remove the orders and add transactions when the OrdersCleaned Event
     assert.fieldEquals('Order', id2, 'filledAmount', '200');
 
     const txId = event.transaction.hash.toHexString();
+    const txId01 = txId + '-0:1';
 
-    assert.fieldEquals('Transaction', txId + '-0:1', 'amount', '90');
+    assert.fieldEquals('Transaction', txId01, 'amount', '90');
     assert.fieldEquals(
         'Transaction',
-        txId + '-0:1',
+        txId01,
         'orderPrice',
         unitPrice.toString()
     );
-    assert.fieldEquals(
-        'Transaction',
-        txId + '-0:1',
-        'currency',
-        ccy.toHexString()
-    );
-    assert.fieldEquals(
-        'Transaction',
-        txId + '-0:1',
-        'maturity',
-        maturity.toString()
-    );
-    assert.fieldEquals('Transaction', txId + ':1', 'side', side.toString());
-    assert.fieldEquals(
-        'Transaction',
-        txId + '-0:1',
-        'taker',
-        maker.toHexString()
-    );
-    assert.fieldEquals('Transaction', txId + '-0:1', 'forwardValue', '100');
+    assert.fieldEquals('Transaction', txId01, 'currency', ccy.toHexString());
+    assert.fieldEquals('Transaction', txId01, 'maturity', maturity.toString());
+    assert.fieldEquals('Transaction', txId01, 'side', side.toString());
+    assert.fieldEquals('Transaction', txId01, 'taker', maker.toHexString());
+    assert.fieldEquals('Transaction', txId01, 'forwardValue', '100');
+    assert.fieldEquals('Transaction', txId01, 'executionType', 'Lazy');
 
+    const txId11 = txId + '-1:1';
+    assert.fieldEquals('Transaction', txId11, 'amount', amount2.toString());
     assert.fieldEquals(
         'Transaction',
-        txId + '-1:1',
-        'amount',
-        amount2.toString()
-    );
-    assert.fieldEquals(
-        'Transaction',
-        txId + '-1:1',
+        txId11,
         'orderPrice',
         unitPrice2.toString()
     );
-    assert.fieldEquals(
-        'Transaction',
-        txId + '-1:1',
-        'currency',
-        ccy.toHexString()
-    );
-    assert.fieldEquals(
-        'Transaction',
-        txId + '-1:1',
-        'maturity',
-        maturity.toString()
-    );
-    assert.fieldEquals('Transaction', txId + '-1:1', 'side', side.toString());
-    assert.fieldEquals(
-        'Transaction',
-        txId + '-1:1',
-        'taker',
-        maker.toHexString()
-    );
-    assert.fieldEquals('Transaction', txId + '-1:1', 'forwardValue', '250');
+    assert.fieldEquals('Transaction', txId11, 'currency', ccy.toHexString());
+    assert.fieldEquals('Transaction', txId11, 'maturity', maturity.toString());
+    assert.fieldEquals('Transaction', txId11, 'side', side.toString());
+    assert.fieldEquals('Transaction', txId11, 'taker', maker.toHexString());
+    assert.fieldEquals('Transaction', txId11, 'forwardValue', '250');
+    assert.fieldEquals('Transaction', txId11, 'executionType', 'Lazy');
 });
 
 test('Should create a Transaction when the OrdersTaken Event is raised', () => {
@@ -358,6 +327,7 @@ test('Should create a Transaction when the OrdersTaken Event is raised', () => {
         'averagePrice',
         averagePrice.toString()
     );
+    assert.fieldEquals('Transaction', id, 'executionType', 'Sync');
 });
 
 test('Should create multiple Transaction when the multiple OrdersTaken Events are emitted under same transaction', () => {
@@ -366,10 +336,6 @@ test('Should create multiple Transaction when the multiple OrdersTaken Events ar
 
     const filledFutureValue = BigInt.fromString('1230000000000000000000');
     const filledAmount = BigInt.fromString('1200000000000000000000');
-
-    const averagePrice = filledAmount.divDecimal(
-        new BigDecimal(filledFutureValue)
-    );
 
     const takeOrdersEvent1 = createOrdersTakenEvent(
         maker,


### PR DESCRIPTION
Extract from a slack discussion which explains the goal of this:

```
I am trying to get the latest transaction for a currency/maturity pair.
We are creating a Transaction entity in the graph when an order is taken, when an order is clean and when an order is partially filled.
If I understand correctly, we always have two Transaction entities by “real” transaction happening. One is created synchronously, and one asynchronously. For Itayose, we have two async ones though.
We could consider the sync one to have the “real” execution timestamp. Therefore, I want to add a field in the Transaction entity to represent the creation mode. I consider calling this field the following, but this is not a great name. :smile:
enum TransactionExecutionType {
  Sync
  Lazy
}
On the UI side, if there is no last sync transaction then it means we are in the Itayose mode, and then we can use the openingUnitPrice
```